### PR TITLE
修改了网站页脚GitHub的指向链接

### DIFF
--- a/Site/docusaurus.config.js
+++ b/Site/docusaurus.config.js
@@ -204,7 +204,7 @@ const config = {
 					// Please change this to your repo.
 					// Remove this to remove the "edit this page" links.
 					editUrl:
-						'https://github.com/pigpigyyy/Dora-SSR/tree/main/Site',
+						'https://github.com/ippclub/Dora-SSR/tree/main/Site',
 					// sidebarCollapsed: false,
 					showLastUpdateAuthor: true,
 					showLastUpdateTime: true,

--- a/Site/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/Site/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -25,7 +25,7 @@
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
-    "description": "The label of footer link with label=GitHub linking to https://github.com/pigpigyyy/Dora-SSR"
+    "description": "The label of footer link with label=GitHub linking to https://github.com/ippclub/Dora-SSR"
   },
   "copyright": {
     "message": "Copyright © 2023 Dora SSR, Inc. Built with Docusaurus.",


### PR DESCRIPTION
![图例](https://image.harkerhand.online/file/aa80f2d3421b82176f6ab.png)

页脚指向的链接已经404不存在了，更改指向到了ippclub/dora-ssr