### PR TITLE
Enhance Web IDE authentication: PIN-confirmation + session HMAC

### DIFF
--- a/Assets/Script/Dev/AuthSession.lua
+++ b/Assets/Script/Dev/AuthSession.lua
@@ -1,0 +1,53 @@
+--[[ Copyright (c) 2016-2026 Li Jin <dragon-fly@qq.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. ]]
+
+local pending = nil
+local session = nil
+
+local export = {}
+
+export.beginPending = function(sessionId, confirmCode, expiresAt, ttl)
+	pending = {
+		sessionId = sessionId,
+		confirmCode = confirmCode,
+		expiresAt = expiresAt,
+		ttl = ttl,
+		approved = false
+	}
+	return pending
+end
+
+export.getPending = function()
+	return pending
+end
+
+export.approvePending = function(sessionId)
+	if pending and pending.sessionId == sessionId then
+		pending.approved = true
+		return true
+	end
+	return false
+end
+
+export.clearPending = function()
+	pending = nil
+end
+
+export.setSession = function(sessionId, sessionSecret)
+	session = {
+		sessionId = sessionId,
+		sessionSecret = sessionSecret
+	}
+	return session
+end
+
+export.getSession = function()
+	return session
+end
+
+return export

--- a/Assets/Script/Dev/AuthSession.yue
+++ b/Assets/Script/Dev/AuthSession.yue
@@ -1,0 +1,40 @@
+--[[ Copyright (c) 2016-2026 Li Jin <dragon-fly@qq.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. ]]
+
+pending = nil
+session = nil
+
+export.beginPending = (sessionId, confirmCode, expiresAt, ttl) ->
+	pending = {
+		:sessionId
+		:confirmCode
+		:expiresAt
+		:ttl
+		approved: false
+	}
+	pending
+
+export.getPending = -> pending
+
+export.approvePending = (sessionId) ->
+	if pending and pending.sessionId == sessionId
+		pending.approved = true
+		return true
+	false
+
+export.clearPending = ->
+	pending = nil
+
+export.setSession = (sessionId, sessionSecret) ->
+	session = {
+		:sessionId
+		:sessionSecret
+	}
+	session
+
+export.getSession = -> session

--- a/Assets/Script/Dev/Entry.yue
+++ b/Assets/Script/Dev/Entry.yue
@@ -865,6 +865,11 @@ authCode = string.format "%06d", math.random 0, 999999
 macro MaxAuthCodeTTL = -> 30
 authCodeTTL = $MaxAuthCodeTTL
 export.getAuthCode = -> authCode
+export.invalidateAuthCode = ->
+	authCode = string.format "%06d", math.random 0, 999999
+	authCodeTTL = $MaxAuthCodeTTL
+
+import "Script.Dev.AuthSession"
 
 transparant = Color 0x0
 windowFlags = $WindowFlag(
@@ -1029,14 +1034,29 @@ footerWindow = threadLoop ->
 				TextColored descColor, zh and '不可用' or 'not available'
 			hovered = IsItemHovered!
 			SameLine!
+			pending = AuthSession.getPending!
 			:themeColor = App
-			PushStyleColor "Text", themeColor, ->
-				ImGui.ProgressBar authCodeTTL / $MaxAuthCodeTTL, Vec2(60, -1), authCode
-				hovered or= IsItemHovered!
-			if hovered
-				BeginTooltip ->
-					PushTextWrapPos 280, ->
-						Text zh and '在本机或是本地局域网连接的其他设备上，使用浏览器访问这个地址并输入后面的 PIN 码来使用 Web IDE' or 'You can use the Web IDE by accessing this address with the following PIN code in a browser on this machine or other devices connected to the local network'
+			if pending
+				remaining = math.max 0, pending.expiresAt - os.time!
+				ttl = pending.ttl or 1
+				PushStyleColor "Text", themeColor, ->
+					ImGui.ProgressBar remaining / ttl, Vec2(60, -1), pending.confirmCode
+					hovered or= IsItemHovered!
+				SameLine!
+				if Button zh and "确认" or "Approve", Vec2 70, 30
+					AuthSession.approvePending pending.sessionId
+				if hovered
+					BeginTooltip ->
+						PushTextWrapPos 280, ->
+							Text zh and 'Web IDE 正在等待确认，请核对浏览器中的会话码并点击确认' or 'Web IDE is waiting for confirmation. Match the session code in the browser and click approve.'
+			else
+				PushStyleColor "Text", themeColor, ->
+					ImGui.ProgressBar authCodeTTL / $MaxAuthCodeTTL, Vec2(60, -1), authCode
+					hovered or= IsItemHovered!
+				if hovered
+					BeginTooltip ->
+						PushTextWrapPos 280, ->
+							Text zh and '在本机或是本地局域网连接的其他设备上，使用浏览器访问这个地址并输入后面的 PIN 码来使用 Web IDE（PIN 仅用于一次认证）' or 'Open this address in a browser on this machine or another device on the local network and enter the PIN below to start the Web IDE (PIN is one-time).'
 
 	unless isInEntry
 		SetNextWindowSize Vec2 50, 50

--- a/Assets/Script/Dev/WebServer.yue
+++ b/Assets/Script/Dev/WebServer.yue
@@ -8,6 +8,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 _ENV = Dora
 import global
+import "Script.Dev.AuthSession"
 
 HttpServer\stop!
 
@@ -19,11 +20,22 @@ HttpServer.authToken = ""
 authFailedCount = 0
 authLockedUntil = 0.0
 
+PendingTTL = 60
+
 genAuthToken = ->
 	parts = {}
 	for _ = 1, 4
 		parts[] = string.format "%08x", math.random 0, 0x7fffffff
 	table.concat parts
+
+genSessionId = ->
+	parts = {}
+	for _ = 1, 2
+		parts[] = string.format "%08x", math.random 0, 0x7fffffff
+	table.concat parts
+
+genConfirmCode = ->
+	string.format "%04d", math.random 0, 9999
 
 HttpServer\post "/auth", (req) ->
 	import "Script.Dev.Entry"
@@ -37,9 +49,14 @@ HttpServer\post "/auth", (req) ->
 			code = code
 	if code and tostring(code) == authCode
 		authFailedCount = 0
-		token = genAuthToken!
-		HttpServer.authToken = token
-		return success: true, token: token
+		Entry.invalidateAuthCode!
+		if pending := AuthSession.getPending!
+			if now < pending.expiresAt and not pending.approved
+				return success: true, pending: true, sessionId: pending.sessionId, confirmCode: pending.confirmCode, expiresIn: pending.expiresAt - now
+		sessionId = genSessionId!
+		confirmCode = genConfirmCode!
+		AuthSession.beginPending sessionId, confirmCode, now + PendingTTL, PendingTTL
+		return success: true, pending: true, sessionId: sessionId, confirmCode: confirmCode, expiresIn: PendingTTL
 	else
 		authFailedCount += 1
 		if authFailedCount >= 3
@@ -47,6 +64,29 @@ HttpServer\post "/auth", (req) ->
 			authLockedUntil = now + 30
 			return success: false, message: "locked", retryAfter: 30
 		return success: false, message: "invalid code"
+
+HttpServer\post "/auth/confirm", (req) ->
+	now = os.time!
+	sessionId = nil
+	switch req
+		when {body: {:sessionId}}
+			sessionId = sessionId
+	unless sessionId
+		return success: false, message: "invalid session"
+	if pending := AuthSession.getPending!
+		if pending.sessionId ~= sessionId
+			return success: false, message: "invalid session"
+		if now >= pending.expiresAt
+			AuthSession.clearPending!
+			return success: false, message: "expired"
+		if pending.approved
+			secret = genAuthToken!
+			HttpServer.authToken = "#{sessionId}:#{secret}"
+			AuthSession.setSession sessionId, secret
+			AuthSession.clearPending!
+			return success: true, sessionId: sessionId, sessionSecret: secret
+		return success: false, message: "pending", retryAfter: 2
+	return success: false, message: "invalid session"
 
 from "Utils" import LintYueGlobals, CheckTIC80Code
 

--- a/Source/Http/HttpServer.h
+++ b/Source/Http/HttpServer.h
@@ -9,6 +9,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #pragma once
 
 #include <chrono>
+#include <mutex>
+#include <unordered_map>
 
 namespace httplib {
 struct Request;
@@ -81,12 +83,18 @@ private:
 	friend class WebSocketServer;
 	std::string _wwwPath;
 	std::string _authToken;
+	std::string _authSessionId;
+	std::string _authSessionSecret;
 	bool _authRequired;
 	bool _authTokenHasExpiry;
 	std::chrono::steady_clock::time_point _authTokenExpiry;
 	static constexpr int AuthTokenTTLSeconds = 1800;
+	static constexpr int AuthSignatureTTLSeconds = 60;
+	std::unordered_map<std::string, std::chrono::steady_clock::time_point> _authNonces;
+	std::mutex _authNonceMutex;
 	bool isAuthorized(const httplib::Request& req);
 	bool isTokenValid(const std::string& token);
+	bool isWebSocketAuthorized(const std::string& resource);
 	std::list<Post> _posts;
 	std::list<PostScheduled> _postScheduled;
 	std::list<File> _files;

--- a/Tools/dora-dora/src/AuthDialog.tsx
+++ b/Tools/dora-dora/src/AuthDialog.tsx
@@ -15,9 +15,14 @@ import {theme as authTheme, Color} from './Theme';
 import {useTranslation} from 'react-i18next';
 import * as Service from './Service';
 
+export type AuthSession = {
+	sessionId: string;
+	sessionSecret: string;
+};
+
 export type AuthDialogProps = {
 	origFetch: typeof window.fetch;
-	onToken: (token: string) => void;
+	onToken: (session: AuthSession) => void;
 };
 
 type PinInputProps = {
@@ -186,6 +191,11 @@ const AuthDialog = ({origFetch, onToken}: AuthDialogProps) => {
 	const [busy, setBusy] = React.useState(false);
 	const [lockedUntil, setLockedUntil] = React.useState(0);
 	const [secondsLeft, setSecondsLeft] = React.useState(0);
+	const [pendingSessionId, setPendingSessionId] = React.useState('');
+	const [confirmCode, setConfirmCode] = React.useState('');
+	const [confirmExpiresAt, setConfirmExpiresAt] = React.useState(0);
+	const [confirmSecondsLeft, setConfirmSecondsLeft] = React.useState(0);
+	const [confirming, setConfirming] = React.useState(false);
 
 	React.useEffect(() => {
 		if (!lockedUntil) return;
@@ -201,9 +211,80 @@ const AuthDialog = ({origFetch, onToken}: AuthDialogProps) => {
 		return () => window.clearInterval(timer);
 	}, [lockedUntil]);
 
+	React.useEffect(() => {
+		if (!confirmExpiresAt) return;
+		const tick = () => {
+			const diff = Math.max(0, Math.ceil((confirmExpiresAt - Date.now()) / 1000));
+			setConfirmSecondsLeft(diff);
+			if (diff === 0) {
+				setConfirmExpiresAt(0);
+			}
+		};
+		tick();
+		const timer = window.setInterval(tick, 1000);
+		return () => window.clearInterval(timer);
+	}, [confirmExpiresAt]);
+
+	const clearPending = React.useCallback(() => {
+		setPendingSessionId('');
+		setConfirmCode('');
+		setConfirmExpiresAt(0);
+		setConfirmSecondsLeft(0);
+		setConfirming(false);
+	}, []);
+
+	React.useEffect(() => {
+		if (!pendingSessionId) return;
+		let active = true;
+		const poll = async (delaySeconds = 0) => {
+			if (delaySeconds > 0) {
+				await new Promise((resolve) => window.setTimeout(resolve, delaySeconds * 1000));
+			}
+			if (!active) return;
+			try {
+				const res = await origFetch(Service.addr('/auth/confirm'), {
+					method: 'POST',
+					headers: {'Content-Type': 'application/json'},
+					body: JSON.stringify({sessionId: pendingSessionId}),
+				});
+				if (!res.ok) {
+					setError(t('auth.error.authFailed'));
+					clearPending();
+					return;
+				}
+				const data = await res.json().catch(() => null);
+				if (data && data.success && data.sessionSecret && data.sessionId) {
+					onToken({
+						sessionId: data.sessionId as string,
+						sessionSecret: data.sessionSecret as string,
+					});
+					return;
+				}
+				if (data && data.message === 'expired') {
+					setError(t('auth.error.confirmExpired'));
+					clearPending();
+					return;
+				}
+				const retryAfter = data && data.retryAfter ? Number(data.retryAfter) : 2;
+				if (active) {
+					void poll(retryAfter);
+				}
+			} catch (err) {
+				void err;
+				setError(t('auth.error.authFailed'));
+				clearPending();
+			}
+		};
+		setConfirming(true);
+		void poll();
+		return () => {
+			active = false;
+		};
+	}, [pendingSessionId, origFetch, clearPending, onToken, t]);
+
 	const handleSubmit = async (overrideCode?: string) => {
 		const nextCode = (overrideCode ?? code).trim();
-		if (!nextCode || busy || secondsLeft > 0) return;
+		if (!nextCode || busy || secondsLeft > 0 || confirming) return;
 		setBusy(true);
 		setError('');
 		try {
@@ -218,8 +299,20 @@ const AuthDialog = ({origFetch, onToken}: AuthDialogProps) => {
 				return;
 			}
 			const data = await res.json().catch(() => null);
-			if (data && data.success && data.token) {
-				onToken(data.token as string);
+			if (data && data.success && data.sessionSecret && data.sessionId) {
+				onToken({
+					sessionId: data.sessionId as string,
+					sessionSecret: data.sessionSecret as string,
+				});
+				return;
+			}
+			if (data && data.success && data.pending && data.sessionId && data.confirmCode) {
+				setPendingSessionId(data.sessionId as string);
+				setConfirmCode(data.confirmCode as string);
+				const expiresIn = Number(data.expiresIn) || 60;
+				setConfirmExpiresAt(Date.now() + expiresIn * 1000);
+				setConfirming(true);
+				setCode('');
 				return;
 			}
 			if (data && data.message === 'locked' && data.retryAfter) {
@@ -258,30 +351,53 @@ const AuthDialog = ({origFetch, onToken}: AuthDialogProps) => {
 				</DialogTitle>
 				<DialogContent sx={{pt: 1.5}}>
 					<Typography variant="body2" sx={{color: 'text.secondary', mb: 2}}>
-						{t('auth.description')}
+						{pendingSessionId ? t('auth.confirmDescription') : t('auth.description')}
 					</Typography>
-					<PinInput
-						autoFocus
-						value={code}
-						onChange={setCode}
-						onComplete={(value) => void handleSubmit(value)}
-						disabled={busy || secondsLeft > 0}
-						error={Boolean(error)}
-						helperText={error || ' '}
-					/>
-					{secondsLeft > 0 ? (
-						<Typography variant="caption" sx={{color: 'text.secondary'}}>
-							{t('auth.waitRetry', {seconds: secondsLeft})}
-						</Typography>
-					) : null}
+					{pendingSessionId ? (
+						<Box sx={{display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1.5}}>
+							<Typography variant="overline" sx={{color: 'text.secondary'}}>
+								{t('auth.confirmCodeLabel')}
+							</Typography>
+							<Typography variant="h4" sx={{fontWeight: 700, letterSpacing: 3}}>
+								{confirmCode || '----'}
+							</Typography>
+							<Typography variant="caption" sx={{color: 'text.secondary'}}>
+								{confirmSecondsLeft > 0
+									? t('auth.waitConfirm', {seconds: confirmSecondsLeft})
+									: t('auth.waitingApproval')}
+							</Typography>
+							{error ? (
+								<Typography variant="caption" sx={{color: 'error.main'}}>
+									{error}
+								</Typography>
+							) : null}
+						</Box>
+					) : (
+						<>
+							<PinInput
+								autoFocus
+								value={code}
+								onChange={setCode}
+								onComplete={(value) => void handleSubmit(value)}
+								disabled={busy || secondsLeft > 0}
+								error={Boolean(error)}
+								helperText={error || ' '}
+							/>
+							{secondsLeft > 0 ? (
+								<Typography variant="caption" sx={{color: 'text.secondary'}}>
+									{t('auth.waitRetry', {seconds: secondsLeft})}
+								</Typography>
+							) : null}
+						</>
+					)}
 				</DialogContent>
-				{busy ? (
+				{busy || confirming ? (
 					<DialogActions sx={{px: 3, pb: 2}}>
 						<Box sx={{flex: 1}} />
 						<Box sx={{display: 'flex', alignItems: 'center', gap: 1}}>
 							<CircularProgress size={16} />
 							<Typography variant="body2" sx={{color: 'text.secondary'}}>
-								{t('auth.verifying')}
+								{pendingSessionId ? t('auth.awaitingApproval') : t('auth.verifying')}
 							</Typography>
 						</Box>
 					</DialogActions>

--- a/Tools/dora-dora/src/i18n.ts
+++ b/Tools/dora-dora/src/i18n.ts
@@ -78,13 +78,19 @@ i18n
 					},
 					auth: {
 						title: "Connect Dora Web IDE",
-						description: "Enter the 6-digit verification code shown in the engine window to complete authentication.",
+						description: "Enter the 6-digit PIN shown in the engine window to start authentication.",
+						confirmDescription: "Confirm the session code in the engine window to finish pairing.",
+						confirmCodeLabel: "Session code",
 						error: {
 							authFailed: "Authentication failed. Please try again.",
 							tooManyAttempts: "Too many attempts. Please retry after {{seconds}}s.",
 							codeInvalid: "Invalid verification code. Please try again.",
+							confirmExpired: "Confirmation expired. Please request a new PIN.",
 						},
 						waitRetry: "Please wait {{seconds}}s before retrying.",
+						waitConfirm: "Confirm within {{seconds}}s.",
+						waitingApproval: "Waiting for approval...",
+						awaitingApproval: "Awaiting approval...",
 						verifying: "Verifying...",
 					},
 					popup: {
@@ -397,13 +403,19 @@ i18n
 					},
 					auth: {
 						title: "连接 Dora Web IDE",
-						description: "请输入引擎窗口中显示的 6 位验证码完成验证。",
+						description: "输入引擎窗口中显示的 6 位 PIN 码以开始认证。",
+						confirmDescription: "在引擎窗口中确认会话码以完成绑定。",
+						confirmCodeLabel: "会话码",
 						error: {
 							authFailed: "认证失败，请重试",
 							tooManyAttempts: "尝试过于频繁，请 {{seconds}}s 后再试",
 							codeInvalid: "验证码错误，请重试",
+							confirmExpired: "确认超时，请重新获取 PIN。",
 						},
 						waitRetry: "请等待 {{seconds}}s 后重试",
+						waitConfirm: "请在 {{seconds}}s 内确认。",
+						waitingApproval: "等待确认中...",
+						awaitingApproval: "等待确认中...",
 						verifying: "验证中...",
 					},
 					popup: {


### PR DESCRIPTION
### Motivation
- Replace the fragile one-off PIN-only scheme with a two-step flow that ensures the same human-controlled session is confirmed inside the engine before granting long-lived access.
- Protect subsequent Web IDE requests by deriving a `session_secret` and using HMAC signatures rather than sending a raw token, reducing replay and tampering risk.
- Make the Web IDE client/engine coordinate to avoid accidental cross-session authorization and guide users through confirmation in the UI.

### Description
- Added a small session manager (`Assets/Script/Dev/AuthSession.{yue,lua}`) and extended engine dev endpoints to support pending sessions, `/auth` (creates pending session + PIN) and `/auth/confirm` (finalize when approved), and to store `sessionId:sessionSecret` as the server auth token (see `Assets/Script/Dev/WebServer.{yue,lua}`).
- Implemented client-side confirmation UI and polling: updated `Tools/dora-dora/src/AuthDialog.tsx` and localized strings in `Tools/dora-dora/src/i18n.ts` to display session code, pending state and approval progress, and updated `Tools/dora-dora/src/index.tsx` to accept a session object from the dialog.
- Added HMAC signing of requests and websocket URLs on the client: `Tools/dora-dora/src/index.tsx` and `Tools/dora-dora/src/Service.ts` now build/time-stamp/nonce + HMAC headers (and signed WS URL) using the `sessionSecret` and include signature headers `X-Dora-Session`, `X-Dora-Timestamp`, `X-Dora-Nonce`, `X-Dora-Signature` for HTTP and query params for WS.
- Server-side verification in `Source/Http/HttpServer.cpp/.h`: parse `sessionId:sessionSecret` from the stored auth token, validate HMAC signature and timestamp/nonce for both HTTP handlers and WebSocket accept, maintain a nonce cache to mitigate replay, and still support legacy token checks where applicable.

### Testing
- No automated unit or integration tests were executed in this change; manual runtime testing was not requested in this environment. All changes were compiled into the repository and committed as a single change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983208cf794832db8e33e58dd28df4c)