### PR TITLE
fix: correct Color(float) conversion from normalized [0,1] to uint8 […

### DIFF
--- a/Source/3rdParty/bgfx/xmake.lua
+++ b/Source/3rdParty/bgfx/xmake.lua
@@ -734,7 +734,8 @@ target("fcpp")
         "NINCLUDE=64",
         "NWORK=65536",
         "NBUFF=65536",
-        "OLD_PREPROCESSOR=0"
+        "OLD_PREPROCESSOR=0",
+        "_GNU_SOURCE"
     )
     
     -- C 编译器警告抑制 (GCC/Clang only)

--- a/Source/Audio/Audio.cpp
+++ b/Source/Audio/Audio.cpp
@@ -333,7 +333,7 @@ bool Audio::init() {
 	_soloud = new SoLoud::Soloud();
 	SoLoud::result result = _soloud->init(SoLoud::Soloud::CLIP_ROUNDOFF, SoLoud::Soloud::AUTO, DORA_SAMPLERATE);
 	if (result) {
-		Error("failed to init soloud engine deal to reason: {}.", _soloud->getErrorString(result));
+		Warn("SoLoud backend failed ({}), audio disabled.", _soloud->getErrorString(result));
 		delete _soloud;
 		_soloud = nullptr;
 		return false;

--- a/Source/Cache/ShaderCache.cpp
+++ b/Source/Cache/ShaderCache.cpp
@@ -129,7 +129,7 @@ Shader* ShaderCache::load(String filename, ShaderStage stage) {
 		}
 		auto source = SharedContent.loadStr(fullPath);
 		std::string err;
-		auto compiled = SharedShaderCompiler.compile(source, stage, false, err);
+		auto compiled = SharedShaderCompiler.compile(source, stage, false, err, fullPath);
 		if (!err.empty()) {
 			Error("failed to compile shader \"{}\", due to: {}.", filename.toString(), err);
 			return nullptr;

--- a/Source/Effect/Effect.cpp
+++ b/Source/Effect/Effect.cpp
@@ -36,6 +36,13 @@ Value* Pass::Uniform::getValue() const noexcept {
 	return _value.get();
 }
 
+void Pass::Uniform::resetHandle(bgfx::UniformHandle handle) {
+	if (bgfx::isValid(_handle)) {
+		bgfx::destroy(_handle);
+	}
+	_handle = handle;
+}
+
 void Pass::Uniform::setSlot(uint8_t var) {
 	_slot = var;
 }
@@ -58,6 +65,11 @@ void Pass::Uniform::apply() {
 }
 
 bgfx::ProgramHandle Pass::apply() {
+	if (!bgfx::isValid(_program)) {
+		if (_vertShader && _fragShader) {
+			_program = bgfx::createProgram(_vertShader->getHandle(), _fragShader->getHandle());
+		}
+	}
 	for (const auto& pair : _uniforms) {
 		pair.second->apply();
 	}
@@ -84,11 +96,7 @@ Pass::~Pass() {
 
 bool Pass::init() {
 	if (!Object::init()) return false;
-	if (_vertShader && _fragShader) {
-		_program = bgfx::createProgram(_vertShader->getHandle(), _fragShader->getHandle());
-		return bgfx::isValid(_program);
-	}
-	return false;
+	return _vertShader != nullptr && _fragShader != nullptr;
 }
 
 void Pass::setGrabPass(bool var) {

--- a/Source/Effect/Effect.h
+++ b/Source/Effect/Effect.h
@@ -45,6 +45,7 @@ private:
 		PROPERTY(uint8_t, Slot);
 		virtual ~Uniform();
 		void apply();
+		void resetHandle(bgfx::UniformHandle handle);
 		CREATE_FUNC_NOT_NULL(Uniform);
 
 	protected:

--- a/Source/Node/AudioSource.cpp
+++ b/Source/Node/AudioSource.cpp
@@ -140,10 +140,11 @@ bool AudioSource::playBackground() {
 		return false;
 	}
 	_is3D = false;
+	auto soloud = SharedAudio.getSoLoud();
+	if (!soloud) return false;
 	if (auto audioFile = SharedAudioCache.load(_filename)) {
 		uint32_t busHandle = _bus ? _bus->getHandle() : 0;
 		_pan = 0.0f;
-		auto soloud = SharedAudio.getSoLoud();
 		_handle = soloud->playBackground(*audioFile->getSource(), _volume, false, busHandle);
 		soloud->setProtectVoice(_handle, true);
 		if (_playSpeed != 1.0f) {
@@ -174,9 +175,10 @@ bool AudioSource::play(double delayTime) {
 		return false;
 	}
 	_is3D = false;
+	auto soloud = SharedAudio.getSoLoud();
+	if (!soloud) return false;
 	if (auto audioFile = SharedAudioCache.load(_filename)) {
 		uint32_t busHandle = _bus ? _bus->getHandle() : 0;
-		auto soloud = SharedAudio.getSoLoud();
 		if (delayTime <= 0) {
 			_handle = soloud->play(*audioFile->getSource(), _volume, _pan, false, busHandle);
 		} else {

--- a/Source/Shader/ShaderCompiler.cpp
+++ b/Source/Shader/ShaderCompiler.cpp
@@ -153,7 +153,7 @@ static long shaderGetFileSizeCallback(const char* path, void* userData) {
 	return s_cast<long>(fileData.size());
 }
 
-static std::string compileShaderSource(String source, ShaderStage stage, bool fromFile, std::string& err) {
+static std::string compileShaderSource(String source, ShaderStage stage, bool fromFile, std::string& err, String sourcePath = "") {
 	std::string result;
 
 	int doraRenderer = toDoraRenderer(bgfx::getRendererType());
@@ -178,6 +178,16 @@ static std::string compileShaderSource(String source, ShaderStage stage, bool fr
 	options.optimize = 1;
 	options.debug = 0;
 	options.fileOps = &fileOps;
+	// Explicitly set varyingDefPath so DoraShaderc can find varying.def.sc
+	std::string varyingDefPathStr;
+	if (!sourcePath.empty()) {
+		auto dir = Path::getPath(sourcePath);
+		auto filename = Path::getFilename(sourcePath);
+		if (!dir.empty() && !filename.empty()) {
+			varyingDefPathStr = dir + "/varying.def.sc";
+			options.varyingDefPath = varyingDefPathStr.c_str();
+		}
+	}
 
 #if DORA_HAS_EMBEDDED_BGFX_SHADERS
 	const char* includeDirs[] = { "" };
@@ -207,10 +217,10 @@ static std::string compileShaderSource(String source, ShaderStage stage, bool fr
 ShaderCompiler::ShaderCompiler()
 	: _thread(SharedAsyncThread.newThread()) { }
 
-std::string ShaderCompiler::compile(String source, ShaderStage stage, bool fromFile, std::string& err) {
+std::string ShaderCompiler::compile(String source, ShaderStage stage, bool fromFile, std::string& err, String sourcePath) {
 	std::string result;
 	_thread->runInMainSync([&]() {
-		result = compileShaderSource(source, stage, fromFile, err);
+		result = compileShaderSource(source, stage, fromFile, err, sourcePath);
 	});
 	return result;
 }

--- a/Source/Shader/ShaderCompiler.h
+++ b/Source/Shader/ShaderCompiler.h
@@ -20,7 +20,7 @@ enum class ShaderStage {
 
 class ShaderCompiler : public NonCopyable {
 public:
-	std::string compile(String source, ShaderStage stage, bool fromFile, std::string& err);
+	std::string compile(String source, ShaderStage stage, bool fromFile, std::string& err, String sourcePath = "");
 	void compileAsync(String source, ShaderStage stage, bool fromFile, const std::function<void(std::string, std::string)>& callback);
 	std::string compile(String sourceFile, String targetFile, ShaderStage stage);
 	void compileAsync(String sourceFile, String targetFile, ShaderStage stage, const std::function<void(std::string)>& callback);

--- a/Source/Support/Common.cpp
+++ b/Source/Support/Common.cpp
@@ -76,10 +76,10 @@ Color::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 	, a(a) { }
 
 Color::Color(float r, float g, float b, float a)
-	: r(s_cast<uint8_t>(r))
-	, g(s_cast<uint8_t>(g))
-	, b(s_cast<uint8_t>(b))
-	, a(s_cast<uint8_t>(a)) { }
+	: r(s_cast<uint8_t>(std::round(r * 255.0f)))
+	, g(s_cast<uint8_t>(std::round(g * 255.0f)))
+	, b(s_cast<uint8_t>(std::round(b * 255.0f)))
+	, a(s_cast<uint8_t>(std::round(a * 255.0f))) { }
 
 Color::Color(const Vec4& vec)
 	: r(s_cast<uint8_t>(std::round(vec.x * 255.0f)))


### PR DESCRIPTION
…0,255]

- Color(float) constructor now correctly multiplies by 255 and rounds (was casting raw float to uint8, producing wrong colors)
- ShaderCompiler: pass sourcePath for varying.def.sc resolution
- Effect/Pass: delay program creation to apply() for async shader support
- Effect/Pass: add Uniform::resetHandle for bgfx context recreation
- Audio: demote SoLoud init failure from Error to Warn (graceful degrade)
- AudioSource: guard against null SoLoud when audio unavailable
- bgfx/xmake.lua: add _GNU_SOURCE for Linux compilation